### PR TITLE
 Added mutation and subscription for read receipt functionality to change message status to read

### DIFF
--- a/app/graphql/mutations/messages/mark_message_as_read.rb
+++ b/app/graphql/mutations/messages/mark_message_as_read.rb
@@ -1,0 +1,29 @@
+module Mutations
+  module Messages
+    class MarkMessageAsRead < BaseMutation
+        argument :chat_id, ID, required: true
+  
+        type [Types::Messages::MessageType]
+  
+        def resolve(chat_id:)
+          user = context[:current_user]
+          raise GraphQL::ExecutionError, "Unauthorized" unless user
+  
+          messages = Message.where(chat_id: chat_id, receiver_id: user.id, read_at: nil)
+  
+          messages.each do |msg|
+            msg.update(read_at: Time.current)
+            # Trigger subscription using chat_id (works for both group and 1-on-1)
+            DemoChatAppSchema.subscriptions.trigger(
+              "message_read",
+              { chat_id: chat_id },
+              msg
+            )
+          end
+  
+          messages
+        end
+    end
+  end
+end
+    

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,6 +4,7 @@ module Types
   class MutationType < Types::BaseObject
     field :send_message, mutation: Mutations::Messages::SendMessage
     field :login_user, mutation: Mutations::Users::LoginUser
+    field :mark_message_as_read, mutation: Mutations::Messages::MarkMessageAsRead
 
   end
 end

--- a/app/graphql/types/subscription_type.rb
+++ b/app/graphql/types/subscription_type.rb
@@ -8,6 +8,18 @@ module Types
       argument :user_id, ID, required: true
     end
     
+    field :message_read, Types::Messages::MessageSubscriptionType, null: true do
+      argument :chat_id, ID, required: true
+    end
+
+    def message_read(chat_id:)
+      if object.present? && object.chat_id.to_s == chat_id.to_s
+        p "Subscription Triggered: Message Read for Chat ID: #{chat_id} - Message ID: #{object.id}"
+        camelize_keys(object.attributes.symbolize_keys)
+      end
+    end
+    
+    
     def notification_received(user_id:)
       p "Hello from subscription Method Notification Received - User ID: #{user_id}, Object: #{object.inspect}"
       camelize_keys(object.symbolize_keys) if object.present? && object[:receiver_id].to_s == user_id.to_s


### PR DESCRIPTION
### Description
This PR includes read receipt functionality for chat ( group or one-to-one ). Created a markMessageAsRead mutation that will change the status of message to read whenever chat opens and messageRead subscription will return the read messages. As soon as markMessagesAsRead mutation is called, a real-time update is pushed for each message, and frontend gets it instantly.